### PR TITLE
ci(docker): fix healthcheck command and update nginx config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - app_logs:/app/logs
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:5000/health || exit 0"]
+      test: ["CMD-SHELL", "curl -f http://localhost:5000/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/nginx.conf
+++ b/nginx.conf
@@ -200,15 +200,23 @@ rtmp {
             live on;
             record off;
             
-            # Push to HLS
+            # Authentication for publishing
+            on_publish http://auth_server:5000/api/stream/auth;
+            on_publish_done http://auth_server:5000/api/stream/end;
+            
+            # HLS configuration
             hls on;
             hls_path /tmp/hls;
-            hls_fragment 3;
-            hls_playlist_length 60;
+            hls_fragment 3s;
+            hls_playlist_length 60s;
             
-            # Allow all origins for development
-            allow publish all;
-            allow play all;
+            # IP restrictions (example)
+            allow publish 127.0.0.1;   # Localhost
+            allow publish 10.0.0.0/8; # Private network
+            deny publish all;
+            
+            # Playback restrictions
+            allow play all; # Or restrict similarly
         }
     }
 }


### PR DESCRIPTION
- Remove incorrect exit 0 from healthcheck command to properly fail when unhealthy
- Add authentication and IP restrictions to RTMP stream configuration
- Update HLS fragment and playlist length settings with explicit time units

## Summary by Sourcery

Enforce RTMP stream security with authentication and IP restrictions, update HLS settings to use explicit time units, and correct Docker healthcheck behavior to fail on unhealthy endpoints.

New Features:
- Add RTMP on_publish and on_publish_done hooks for stream authentication
- Restrict RTMP publishing to localhost and private-network IP ranges

Enhancements:
- Specify explicit time units for HLS fragment and playlist length in nginx configuration

CI:
- Remove `|| exit 0` from Docker Compose healthcheck to ensure failures are detected